### PR TITLE
Fix indentation in Router.js file

### DIFF
--- a/nontclient/src/Router/Router.js
+++ b/nontclient/src/Router/Router.js
@@ -3,14 +3,14 @@ import { BrowserRouter, Switch, Route, Redirect } from "react-router-dom";
 import Homepage from "../Components/Homepage/Homepage";
 
 function Router() {
-  return ( 
-		<BrowserRouter>
-			<Switch>
-				<Route path="/home" component={Homepage} />
-				<Redirect to="/home"/>
-			</Switch>
-		</BrowserRouter>
-	);
+  return (
+    <BrowserRouter>
+      <Switch>
+        <Route path="/home" component={Homepage} />
+        <Redirect to="/home" />
+      </Switch>
+    </BrowserRouter>
+  );
 }
 
 export default Router;


### PR DESCRIPTION
I don't know why but the indent size (which should be 2) is 4 in Router.js

This pull request just fixes this issue.

There is no need to review, right?