### PR TITLE
Fix the rendering when "distance == 0" in Find Shelter

### DIFF
--- a/nontclient/src/Components/FindShelter/ShelterCard.js
+++ b/nontclient/src/Components/FindShelter/ShelterCard.js
@@ -50,7 +50,7 @@ const ShelterCard = (props) => {
             <div className="d-flex">
               <StarRating rate={shelter.rate} />
             </div>
-            {shelter.distance && (
+            {shelter.distance !== undefined && (
               <div className="d-flex">
                 <span className={styles.fade}>
                   <i className="fas fa-location-arrow mr-1"></i>


### PR DESCRIPTION
If ` distance == 0`, the distance will not be rendered properly. This pull request fixed the issue.