### PR TITLE
set up openapi 3.0

### DIFF
--- a/nontserver/openapi/openapi.yaml
+++ b/nontserver/openapi/openapi.yaml
@@ -7,13 +7,24 @@ servers:
   - description: Nont server 
     url: https://nontserver.herokuapp.com
 paths:
+  # room
   /room:
     $ref: 'room.yaml#/~1room'
   /room/id/{id}:
-    $ref: 'room.yaml#/~1room~1id~1%7Bid%7D'
-components:
-  schemas:
-    Room:
-      $ref: 'schema.yaml#/Room'
-    Rooms:
-      $ref: 'schema.yaml#/Rooms'
+    $ref: 'room.yaml#/~1room~1id~1{id}'
+  /room/name/{name}:
+    $ref: 'room.yaml#/~1room~1name~1{name}'
+  /room/nont-type/{type}:
+    $ref: 'room.yaml#/~1room~1nont-type~1{type}'
+  /room/shelterid/{id}:
+    $ref: 'room.yaml#/~1room~1shelterid~1{id}'
+  /room/update/{id}:
+    $ref: 'room.yaml#/~1room~1update~1{id}'
+  /room/delete/{id}:
+    $ref: 'room.yaml#/~1room~1delete~1{id}'
+  /room/remove/{id}:
+    $ref: 'room.yaml#/~1room~1remove~1{id}'
+  /room/admin_update/{id}:
+    $ref: 'room.yaml#/~1room~1admin_update~1{id}'
+  /room/admin_get/{id}:
+    $ref: 'room.yaml#/~1room~1admin_get~1{id}'

--- a/nontserver/openapi/openapi.yaml
+++ b/nontserver/openapi/openapi.yaml
@@ -1,0 +1,19 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Nont API
+  description: ''
+servers:
+  - description: Nont server 
+    url: https://nontserver.herokuapp.com
+paths:
+  /room:
+    $ref: 'room.yaml#/~1room'
+  /room/id/{id}:
+    $ref: 'room.yaml#/~1room~1id~1%7Bid%7D'
+components:
+  schemas:
+    Room:
+      $ref: 'schema.yaml#/Room'
+    Rooms:
+      $ref: 'schema.yaml#/Rooms'

--- a/nontserver/openapi/room.yaml
+++ b/nontserver/openapi/room.yaml
@@ -1,13 +1,28 @@
 /room:
-      get:
-        description: fetch all rooms
-        responses:
-          200:
-            description: Success Response
-            content:
-              application/json:
-                schema:
-                  $ref: 'schema.yaml#/Rooms'
+  get:
+    description: fetch all rooms
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Rooms"
+  post:
+    description: create new room
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/requestBodies/createBody"
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Room"
 /room/id/{id}:
   get:
     description: fetch one room using room_id
@@ -23,4 +38,174 @@
         content:
           application/json:
             schema:
-              $ref: 'schema.yaml#/Room'
+              $ref: "schema.yaml#/Room"
+/room/name/{name}:
+  get:
+    description: fetch rooms using room_name
+    parameters:
+      - in: path
+        name: name
+        required: true
+        schema:
+          type: string
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Rooms"
+/room/nont-type/{type}:
+  get:
+    description: fetch rooms using nont_type
+    parameters:
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Rooms"
+/room/shelterid/{id}:
+  get:
+    description: fetch rooms using shelter_id
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Rooms"
+/room/update/{id}:
+  patch:
+    description: update room
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/requestBodies/updateBody"
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Room"
+/room/delete/{id}:
+  patch:
+    description: delete room (update exist to false)
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Room"
+/room/remove/{id}:
+  delete:
+    description: remove room from database
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    responses:
+      200:
+        description: Success Response
+/room/admin_update/{id}:
+  put:
+    description: update room
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/requestBodies/updateBody"
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Room"
+/room/admin_get/{id}:
+  get:
+    description: fetch one room using room_id
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: "schema.yaml#/Room"
+
+components:
+  requestBodies:
+    createBody:
+      type: object
+      required:
+        - name
+        - nont_type
+        - amount
+        - price
+        - shelter_id
+      properties:
+        name:
+          type: string
+        nont_type:
+          type: string
+        amount:
+          type: number
+        price:
+          type: number
+        shelter_id:
+          type: string
+
+    updateBody:
+      type: object
+      properties:
+        name:
+          type: string
+        nont_type:
+          type: string
+        amount:
+          type: number
+        price:
+          type: number

--- a/nontserver/openapi/room.yaml
+++ b/nontserver/openapi/room.yaml
@@ -1,0 +1,26 @@
+/room:
+      get:
+        description: fetch all rooms
+        responses:
+          200:
+            description: Success Response
+            content:
+              application/json:
+                schema:
+                  $ref: 'schema.yaml#/Rooms'
+/room/id/{id}:
+  get:
+    description: fetch one room using room_id
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+    responses:
+      200:
+        description: Success Response
+        content:
+          application/json:
+            schema:
+              $ref: 'schema.yaml#/Room'

--- a/nontserver/openapi/schema.yaml
+++ b/nontserver/openapi/schema.yaml
@@ -1,0 +1,36 @@
+Room:
+  type: object
+  required:
+    - _id
+    - name
+    - nont_type
+    - amount
+    - price
+    - shelter_id
+    - exist
+  properties:
+    _id:
+      type: string
+    name:
+      type: string
+    nont_type:
+      type: string
+    amount:
+      type: number
+    price:
+      type: number
+    shelter_id:
+      type: string
+    exist:
+      type: boolean
+    createdAt:
+      type: string
+    updatedAt:
+      type: string
+    __v:
+      type: integer
+Rooms:
+  description: array of Room
+  type: array
+  items:
+    $ref: '#/Room'

--- a/nontserver/openapi/schema.yaml
+++ b/nontserver/openapi/schema.yaml
@@ -1,13 +1,5 @@
 Room:
   type: object
-  required:
-    - _id
-    - name
-    - nont_type
-    - amount
-    - price
-    - shelter_id
-    - exist
   properties:
     _id:
       type: string


### PR DESCRIPTION
เนื่องจากตัว SwaggerHub ไม่สามารถใช้งานเป็นกลุ่มได้ จึงได้ไปหาตัวเลือกอื่นมาและได้พบกับ extension บน vs code ที่ชื่อว่า [**swagger viewer**](https://marketplace.visualstudio.com/items?itemName=Arjun.swagger-viewer) ซึ่งสามารถแปลงไฟล์ json หรือ yaml ให้ออกมาเหมือนในหน้าเว็บของ swagger อีกทั้งยังสามารถเปิดเป็น tab หนึ่งใน vs code ได้เลย

![image](https://user-images.githubusercontent.com/32786620/114025460-53ea0600-989f-11eb-8dc8-ac52974735d7.png)

ถ้าเราเลือกใช้ extension นี้ในการพัฒนา swagger เราจะสามารถใช้ vs code ในการพัฒนาได้เลย 
**นั่นคือเราจะใช้วิธี commit ขึ้น github ได้ตามปกติ**
โดยกระผมได้ลองใช้งานเบื้องต้นแล้วพบว่า เราสามารถแยกไฟล์เขียนและ ref ไปมาระหว่างไฟล์ได้อย่างอิสระ

เราจะมี openapi.yaml เป็นตัวหลักที่จะ [ref](https://github.com/2110336-SoftwareEngineering2/sec33_Kojira/blob/142e71f518be82c25e6b9d675e971dacc6f4045f/nontserver/openapi/openapi.yaml#L11) ไปหาไฟล์อื่น เช่น room.yaml schema.yaml เป็นต้น
ทั้งนี้ในไฟล์ openapi.yaml จำเป็นต้องระบุ path ทั้งหมดที่เราสร้าง เนื่องจากเท่าที่หาข้อมูลดู**ยังไม่พบว่า swagger อนุญาตให้เราสร้าง sub path** ได้