### PR TITLE
[CI] update environment to match heroku server

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
- we use heroku stack version 20, which is ubuntu 20.04, so update environment of CI to ubuntu-20.04 too (not ubuntu-latest)